### PR TITLE
Try to avoid a possible PROGMEM overflow in getKeyOverride

### DIFF
--- a/src/Kaleidoscope/EEPROM-Keymap.cpp
+++ b/src/Kaleidoscope/EEPROM-Keymap.cpp
@@ -53,8 +53,17 @@ Key EEPROMKeymap::getKeyOverride(uint8_t layer, byte row, byte col) {
   Key key;
 
   key = getKey(layer, row, col);
-  if (key == Key_Transparent || layer >= max_layers_)
+
+  /*
+  * If we read a transparent key from EEPROM, or we're trying to read from a
+  * layer higher than what is available there (max_layers), check if we're below
+  * the layer count in PROGMEM (layer_count). If we are, read from PROGMEM,
+  * otherwise leave the key as-is (either transparent or NoKey).
+  */
+  if ((key == Key_Transparent || layer >= max_layers) &&
+      (layer < layer_count))
     key = Layer.getKeyFromPROGMEM(layer, row, col);
+
   return key;
 }
 


### PR DESCRIPTION
If we're looking up a key from `PROGMEM`, only do that if the layer in question is smaller than `layer_count`. Doing otherwise would read garbage from `PROGMEM` in case we try to read from a layer higher than what we have in there. This can happen if we have more layers in `EEPROM` than in `PROGMEM`.
