### PR TITLE
Automatically pull in EEPROMSettings, and set up defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,9 @@ We can then update the keymap via [Focus][plugin:focus].
 ```c++
 #include <Kaleidoscope.h>
 #include <Kaleidoscope-EEPROM-Keymap.h>
-#include <Kaleidoscope-EEPROM-Settings.h>
 #include <Kaleidoscope-Focus.h>
 
-KALEIDOSCOPE_INIT_PLUGINS(EEPROMSettings,
-                          EEPROMKeymap,
+KALEIDOSCOPE_INIT_PLUGINS(EEPROMKeymap,
                           Focus);
 
 void setup() {
@@ -52,10 +50,7 @@ void setup() {
   Focus.addHook(FOCUS_HOOK_KEYMAP);
   Focus.addHook(FOCUS_HOOK_KEYMAP_TRANSFER);
 
-  Layer.getKey = EEPROMKeymap.getKeyOverride;
-
   EEPROMKeymap.max_layers(1);
-  EEPROMSettings.seal();
 }
 ```
 

--- a/examples/EEPROM-Keymap/EEPROM-Keymap.ino
+++ b/examples/EEPROM-Keymap/EEPROM-Keymap.ino
@@ -20,7 +20,7 @@
 #include <Kaleidoscope-Focus.h>
 
 // *INDENT-OFF*
-const Key keymaps[][ROWS][COLS] PROGMEM = {
+KEYMAPS(
   [0] = KEYMAP_STACKED
   (Key_NoKey,         Key_1, Key_2, Key_3, Key_4, Key_5, Key_NoKey,
    Key_Backtick,      Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
@@ -37,10 +37,10 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
 
    Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
    Key_skip),
-};
+)
 // *INDENT-ON*
 
-KALEIDOSCOPE_INIT_PLUGINS(EEPROMSettings, EEPROMKeymap, Focus);
+KALEIDOSCOPE_INIT_PLUGINS(EEPROMKeymap, Focus);
 
 void setup() {
   Serial.begin(9600);
@@ -53,10 +53,7 @@ void setup() {
   Focus.addHook(FOCUS_HOOK_HELP);
   Focus.addHook(FOCUS_HOOK_VERSION);
 
-  Layer.getKey = EEPROMKeymap.getKeyOverride;
-
   EEPROMKeymap.max_layers(1);
-  EEPROMSettings.seal();
 }
 
 void loop() {

--- a/src/Kaleidoscope/EEPROM-Keymap.cpp
+++ b/src/Kaleidoscope/EEPROM-Keymap.cpp
@@ -23,6 +23,13 @@ namespace kaleidoscope {
 uint16_t EEPROMKeymap::keymap_base_;
 uint8_t EEPROMKeymap::max_layers_;
 
+EventHandlerResult EEPROMKeymap::onSetup() {
+  ::EEPROMSettings.onSetup();
+  Layer.getKey = ::EEPROMKeymap.getKeyOverride;
+
+  return EventHandlerResult::OK;
+}
+
 void EEPROMKeymap::max_layers(uint8_t max) {
   max_layers_ = max;
   keymap_base_ = ::EEPROMSettings.requestSlice(max_layers_ * ROWS * COLS * 2);

--- a/src/Kaleidoscope/EEPROM-Keymap.h
+++ b/src/Kaleidoscope/EEPROM-Keymap.h
@@ -25,6 +25,8 @@ class EEPROMKeymap : public kaleidoscope::Plugin {
  public:
   EEPROMKeymap(void) {}
 
+  EventHandlerResult onSetup();
+
   static void max_layers(uint8_t max);
 
   static uint16_t keymap_base(void);


### PR DESCRIPTION
To make it easier to use the plugin, pull in `EEPROMSettings` by default, and explicitly call its `onSetup` (it is safe to do so), so user sketches don't have to if they don't use `EEPROMSettings` directly. Also set `Layer.getKey` to `EEPROMKeymap.getKeyOverride` to provide a sensible default.
