### PR TITLE
Migrate to the onFocusEvent API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,37 +18,31 @@ overlay there. In the latter case, whenever there is a non-transparent key on
 the overlay, we will use that instead of the keyboard default.
 
 In short, this plugin allows us to change our keymaps, without having to compile
-and flash new firmware. It does so through the use of the [Focus][plugin:focus]
-plugin.
+and flash new firmware. It does so through the use of the
+[FocusSerial][plugin:focusSerial] plugin.
 
- [plugin:focus]: https://github.com/keyboardio/Kaleidoscope-Focus
+ [plugin:focusSerial]: https://github.com/keyboardio/Kaleidoscope-FocusSerial
 
 ## Using the plugin
 
 Using the plugin is reasonably simple: after including the header, enable the
-plugin, and let the `Layer` object know that we'll be using `EEPROMKeymap` to
-figure out which keys to use. We can either use the `getKeyOverride` or the
-`getKey` method, depending on whether we want to override, or fully replace the
-built-in keymap. Then we need to set at most how many layers we want to store in
-`EEPROM`, and that is about it.
+plugin, and configure how many layers at most we want to store in `EEPROM`.
+There are other settings one can tweak, but these two steps are enough to get
+started with.
 
-We can then update the keymap via [Focus][plugin:focus].
+Once these are set up, we can update the keymap via [Focus][plugin:focusSerial].
 
 ```c++
 #include <Kaleidoscope.h>
 #include <Kaleidoscope-EEPROM-Keymap.h>
-#include <Kaleidoscope-Focus.h>
+#include <Kaleidoscope-FocusSerial.h>
 
 KALEIDOSCOPE_INIT_PLUGINS(EEPROMKeymap,
-                          Focus);
+                          Focus,
+                          FocusKeymapTransferCommand);
 
 void setup() {
-  Serial.begin(9600);
-
   Kaleidoscope.setup();
-
-  Focus.addHook(FOCUS_HOOK_KEYMAP);
-  Focus.addHook(FOCUS_HOOK_KEYMAP_TRANSFER);
 
   EEPROMKeymap.max_layers(1);
 }
@@ -68,9 +62,8 @@ The plugin provides the `EEPROMKeymap` object, which has the following methods:
 
 ## Focus commands
 
-The plugin provides three `Focus` hooks: `FOCUS_HOOK_KEYMAP`, `FOCUS_HOOK_KEYMAP_LAYER`,
-and `FOCUS_HOOK_KEYMAP_TRANSFER`. Together, they make the following commands
-available, respectively:
+The plugin provides a `keymap.map` Focus command unconditionally, and a
+`keymap.transfer` via the `FocusKeymapTransferCommand` object.
 
 ### `keymap.map [codes...]`
 
@@ -81,13 +74,6 @@ available, respectively:
 > keys, on all layers: the command will start from the first key on the first
 > layer, and go on as long as it has input. It will not go past the layer set
 > via the `.max_layers()` method.
-
-### `keymap.layer LAYER [codes...]`
-
-> Without codes, prints the keymap for the given layer (zero-indexed).
-> Prints each key as its raw 16-bit keycode.
-
-> With codes, stores them as the keymap for the given layer.
 
 ### `keymap.transfer LAYER`
 
@@ -103,7 +89,7 @@ available, respectively:
 ## Dependencies
 
 * [Kaleidoscope-EEPROM-Settings](https://github.com/keyboardio/Kaleidoscope-EEPROM-Settings)
-* [Kaleidoscope-Focus](https://github.com/keyboardio/Kaleidoscope-Focus)
+* [Kaleidoscope-FocusSerial](https://github.com/keyboardio/Kaleidoscope-FocusSerial)
 
 ## Further reading
 

--- a/examples/EEPROM-Keymap/EEPROM-Keymap.ino
+++ b/examples/EEPROM-Keymap/EEPROM-Keymap.ino
@@ -17,7 +17,7 @@
 
 #include <Kaleidoscope.h>
 #include <Kaleidoscope-EEPROM-Keymap.h>
-#include <Kaleidoscope-Focus.h>
+#include <Kaleidoscope-FocusSerial.h>
 
 // *INDENT-OFF*
 KEYMAPS(
@@ -40,18 +40,10 @@ KEYMAPS(
 )
 // *INDENT-ON*
 
-KALEIDOSCOPE_INIT_PLUGINS(EEPROMKeymap, Focus);
+KALEIDOSCOPE_INIT_PLUGINS(EEPROMKeymap, Focus, FocusKeymapTransfer);
 
 void setup() {
-  Serial.begin(9600);
-
   Kaleidoscope.setup();
-
-  Focus.addHook(FOCUS_HOOK_SETTINGS);
-  Focus.addHook(FOCUS_HOOK_KEYMAP);
-  Focus.addHook(FOCUS_HOOK_KEYMAP_TRANSFER);
-  Focus.addHook(FOCUS_HOOK_HELP);
-  Focus.addHook(FOCUS_HOOK_VERSION);
 
   EEPROMKeymap.max_layers(1);
 }

--- a/src/Kaleidoscope-EEPROM-Keymap.h
+++ b/src/Kaleidoscope-EEPROM-Keymap.h
@@ -18,4 +18,4 @@
 #pragma once
 
 #include <Kaleidoscope/EEPROM-Keymap.h>
-#include <Kaleidoscope/EEPROM-Keymap-Focus.h>
+#include <Kaleidoscope/EEPROM-Keymap-Transfer.h>

--- a/src/Kaleidoscope/EEPROM-Keymap-Transfer.cpp
+++ b/src/Kaleidoscope/EEPROM-Keymap-Transfer.cpp
@@ -1,0 +1,50 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-EEPROM-Keymap -- EEPROM-based keymap support.
+ * Copyright (C) 2017, 2018  Keyboard.io, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <Kaleidoscope-EEPROM-Settings.h>
+#include <Kaleidoscope-EEPROM-Keymap.h>
+#include <Kaleidoscope-FocusSerial.h>
+
+namespace kaleidoscope {
+namespace eeprom {
+
+EventHandlerResult FocusKeymapTransferCommand::onFocusEvent(const char *command) {
+  const char *cmd = PSTR("keymap.transfer");
+
+  if (::Focus.handleHelp(command, cmd))
+    return EventHandlerResult::OK;
+  if (strcmp_P(command, cmd) != 0)
+    return EventHandlerResult::OK;
+
+  uint8_t layer = Serial.parseInt();
+
+  for (uint8_t row = 0; row < ROWS; row++) {
+    for (uint8_t col = 0; col < COLS; col++) {
+      Key k = Layer.getKeyFromPROGMEM(layer, row, col);
+      uint16_t pos = ((layer * ROWS * COLS) + (row * COLS) + col);
+
+      ::EEPROMKeymap.updateKey(pos, k);
+    }
+  }
+
+  return EventHandlerResult::EVENT_CONSUMED;
+}
+
+}
+}
+
+kaleidoscope::eeprom::FocusKeymapTransferCommand FocusKeymapTransferCommand;

--- a/src/Kaleidoscope/EEPROM-Keymap-Transfer.h
+++ b/src/Kaleidoscope/EEPROM-Keymap-Transfer.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Kaleidoscope-EEPROM-Keymap -- EEPROM-based keymap support.
- * Copyright (C) 2017  Keyboard.io, Inc
+ * Copyright (C) 2017-2018  Keyboard.io, Inc
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -20,10 +20,15 @@
 #include <Kaleidoscope.h>
 #include <Kaleidoscope/EEPROM-Keymap.h>
 
-#define FOCUS_HOOK_KEYMAP FOCUS_HOOK(EEPROMKeymap.focusKeymap, "keymap.map")
+namespace kaleidoscope {
+namespace eeprom {
+class FocusKeymapTransferCommand : public Plugin {
+ public:
+  FocusKeymapTransferCommand() {}
 
-#define FOCUS_HOOK_KEYMAP_LAYER FOCUS_HOOK(EEPROMKeymap.focusKeymapLayer, \
-                                           "keymap.layer")
+  EventHandlerResult onFocusEvent(const char *command);
+};
+}
+}
 
-#define FOCUS_HOOK_KEYMAP_TRANSFER FOCUS_HOOK(EEPROMKeymap.focusKeymapTransfer, \
-                                              "keymap.transfer")
+extern kaleidoscope::eeprom::FocusKeymapTransferCommand FocusKeymapTransferCommand;

--- a/src/Kaleidoscope/EEPROM-Keymap.h
+++ b/src/Kaleidoscope/EEPROM-Keymap.h
@@ -26,6 +26,7 @@ class EEPROMKeymap : public kaleidoscope::Plugin {
   EEPROMKeymap(void) {}
 
   EventHandlerResult onSetup();
+  EventHandlerResult onFocusEvent(const char *command);
 
   static void max_layers(uint8_t max);
 
@@ -33,10 +34,6 @@ class EEPROMKeymap : public kaleidoscope::Plugin {
 
   static Key getKey(uint8_t layer, byte row, byte col);
   static Key getKeyOverride(uint8_t layer, byte row, byte col);
-
-  static bool focusKeymap(const char *command);
-  static bool focusKeymapLayer(const char *command);
-  static bool focusKeymapTransfer(const char *command);
 
   static void updateKey(uint16_t base_pos, Key key);
 


### PR DESCRIPTION
While there, drop the `keymap.layer` command, which was a workaround to a Chrysalis bug fixed since.
